### PR TITLE
Add backfill script for email lowercasing

### DIFF
--- a/scripts/backfill-email-lower.cjs
+++ b/scripts/backfill-email-lower.cjs
@@ -1,0 +1,14 @@
+const { PrismaClient } = require("@prisma/client");
+const prisma = new PrismaClient();
+
+(async () => {
+  const users = await prisma.user.findMany({ select: { id: true, email: true, emailLower: true } });
+  for (const u of users) {
+    const lower = (u.email ?? "").trim().toLowerCase() || null;
+    if (lower !== u.emailLower) {
+      await prisma.user.update({ where: { id: u.id }, data: { emailLower: lower } });
+    }
+  }
+  console.log(`Backfilled ${users.length} users.`);
+  await prisma.$disconnect();
+})();


### PR DESCRIPTION
## Summary
- add script to backfill `emailLower` field for users

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: requires interactive ESLint setup)


------
https://chatgpt.com/codex/tasks/task_e_68a456e9987c83299cb124b05aa18e5f